### PR TITLE
use config to convert exception to status codes

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,13 @@ parameters:
   env(ELASTIC_HOST): 'elasticsearch:9200'
   env(DATABASE_URL): 'mysql://root:api@mysql:3306/api?serverVersion=8.0'
 
+  exception_to_status:
+    InvalidArgumentException: 400
+    App\Domain\User\Exception\InvalidCredentialsException: 401
+    App\Domain\User\Exception\ForbiddenException: 403
+    App\Domain\Shared\Query\Exception\NotFoundException: 404
+    Broadway\Repository\AggregateNotFoundException: 404
+
 services:
     _defaults:
         autowire: true
@@ -85,6 +92,7 @@ services:
     App\UI\Http\Rest\EventSubscriber\ExceptionSubscriber:
         arguments:
             - "%kernel.environment%"
+            - "%exception_to_status%"
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.exception' }
 

--- a/src/UI/Http/Rest/EventSubscriber/ExceptionSubscriber.php
+++ b/src/UI/Http/Rest/EventSubscriber/ExceptionSubscriber.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace App\UI\Http\Rest\EventSubscriber;
 
-use App\Domain\Shared\Query\Exception\NotFoundException;
-use App\Domain\User\Exception\ForbiddenException;
-use App\Domain\User\Exception\InvalidCredentialsException;
-use Broadway\Repository\AggregateNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,9 +15,10 @@ use Throwable;
 final class ExceptionSubscriber implements EventSubscriberInterface
 {
     private string $environment;
+
     private array $exceptionToStatus;
 
-    public function __construct(string $environment, array $exceptionToStatus)
+    public function __construct(string $environment, array $exceptionToStatus = [])
     {
         $this->environment = $environment;
         $this->exceptionToStatus = $exceptionToStatus;
@@ -90,10 +87,8 @@ final class ExceptionSubscriber implements EventSubscriberInterface
         $exceptionClass = \get_class($exception);
 
         foreach ($this->exceptionToStatus as $class => $status) {
-            if (is_a($exceptionClass, $class, true)) {
+            if (\is_a($exceptionClass, $class, true)) {
                 return $status;
-
-                break;
             }
         }
 

--- a/tests/UI/Http/Rest/EventSubscriber/JsonBodyParserSubscriberTest.php
+++ b/tests/UI/Http/Rest/EventSubscriber/JsonBodyParserSubscriberTest.php
@@ -33,7 +33,7 @@ class JsonBodyParserSubscriberTest extends TestCase
         $request->headers->set('Content-Type', 'application/json');
 
         $requestEvent = new RequestEvent(
-            $this->prophesize(HttpKernelInterface::class)->reveal(),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );


### PR DESCRIPTION
Inspired from https://api-platform.com/docs/core/errors/#converting-php-exceptions-to-http-errors.

I think this way it's easier to override status code rather than adding another `if` statement in `ExceptionSubscriber`

P.S. I've also fixed unit test for `JsonBodyParserSubscriberTest.php` because it throws a depreciation exception causing failed tests