### PR TITLE
fix: phpstan analysis should be relative to project

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
 	checkMissingIterableValueType: false
 	excludes_analyse:
-		- /app/src/Infrastructure/Share/Migrations/*
+		- src/Infrastructure/Share/Migrations/*


### PR DESCRIPTION
When running phpstan command from outside Docker, it ignores `excludes_analyse` sources because they are relative to Docker image instead of project root