### PR TITLE
feat: log ES requests to specific channel

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,10 +1,16 @@
 monolog:
+    channels: ['elasticsearch']
     handlers:
+        elasticsearch:
+            type: stream
+            path: "%kernel.logs_dir%/elasticsearch_%kernel.environment%.log"
+            level: debug
+            channels: ["elasticsearch"]
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-            channels: ["!event"]
+            channels: ["!event", "!elasticsearch"]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/src/Infrastructure/Share/Event/Query/EventElasticRepository.php
+++ b/src/Infrastructure/Share/Event/Query/EventElasticRepository.php
@@ -10,11 +10,9 @@ use Broadway\Domain\DomainMessage;
 
 final class EventElasticRepository extends ElasticRepository implements EventRepositoryInterface
 {
-    private const INDEX = 'events';
-
-    public function __construct(array $elasticConfig)
+    protected function index(): string
     {
-        parent::__construct($elasticConfig, self::INDEX);
+        return 'events';
     }
 
     public function store(DomainMessage $message): void


### PR DESCRIPTION
This is really helpfull for debug as some ES requests are processed asynchronously (like update from Messenger consumer).

Logs are dumped in `var/logs/es_dev.log`. This config only applies on dev environment and fallbacks to main logger if `$esLogger` is not configured.

This is based on https://symfony.com/doc/current/logging/channels_handlers.html#how-to-autowire-logger-channels

Two kind of logger:

## Logger configuration

Activated with [`$defaultConfig['logger'] = $esLogger;`](https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/compare/master...jon-ht:feature/es-log-channel?expand=1#diff-95cc67401d85d9dbe5e6243ebae79b32R23)

```
[2020-05-26T19:31:15.735262+00:00] es.DEBUG: Request Body ["{\"type\":\"App.Domain.User.Event.UserWasCreated\",\"payload\":{\"uuid\":\"0b527786-b07a-4472-bbd0-985e1c695d08\",\"credentials\":{\"email\":\"foo@foo.com\",\"password\":\"$2y$12$8hdOOAy7KgcmUb0fBPu0WOfsHg8w8DNQ\\/73khUx5izhUgR4GEGzPe\"},\"created_at\":\"2020-05-26T19:30:55.903978+00:00\"},\"occurred_on\":\"2020-05-26T19:30:55.915850+00:00\"}"] []
[2020-05-26T19:31:15.739068+00:00] es.INFO: Request Success: {"method":"POST","uri":"http://elasticsearch/events/_doc","port":9200,"headers":{"Host":["elasticsearch"],"Content-Type":["application/json"],"Accept":["application/json"],"User-Agent":["elasticsearch-php/7.6.1 (Linux 4.19.76-linuxkit; PHP 7.4.3)"]},"HTTP code":201,"duration":0.254767} []
[2020-05-26T19:31:15.741196+00:00] es.DEBUG: Response [{"_index":"events","_type":"_doc","_id":"sKR3UnIBt3BSclW_suY3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}] []
```

## Tracer configuration

Activated with [`$defaultConfig['tracer'] = $esLogger;`](https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/compare/master...jon-ht:feature/es-log-channel?expand=1#diff-95cc67401d85d9dbe5e6243ebae79b32R24)

```
[2020-05-26T19:31:15.742195+00:00] es.INFO: curl -XPOST 'http://elasticsearch/events/_doc?pretty=true' -d '{"type":"App.Domain.User.Event.UserWasCreated","payload":{"uuid":"0b527786-b07a-4472-bbd0-985e1c695d08","credentials":{"email":"foo@foo.com","password":"$2y$12$8hdOOAy7KgcmUb0fBPu0WOfsHg8w8DNQ\/73khUx5izhUgR4GEGzPe"},"created_at":"2020-05-26T19:30:55.903978+00:00"},"occurred_on":"2020-05-26T19:30:55.915850+00:00"}' [] []
[2020-05-26T19:31:15.743282+00:00] es.DEBUG: Response: {"response":{"_index":"events","_type":"_doc","_id":"sKR3UnIBt3BSclW_suY3","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1},"method":"POST","uri":"http://elasticsearch/events/_doc","HTTP code":201,"duration":0.254767} []
```