### PR TITLE
Change retry strategy for messenger

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -16,7 +16,11 @@ framework:
             messenger.bus.event.async: ~
 
         transports:
-            events: "%env(MESSENGER_TRANSPORT_DSN)%"
+            events:
+                dsn: "%env(MESSENGER_TRANSPORT_DSN)%"
+                retry_strategy:
+                    delay: 2000
+                    max_retries: 5
 
         routing:
             'App\Infrastructure\Share\Bus\Event\EventInterface': events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,17 @@ services:
     depends_on:
       - mysql
       - rmq
+      - elasticsearch
 
   workers:
     image: jorge07/alpine-php:7.4.3-dev
     volumes:
       - .:/app
     command: ['/app/bin/console', 'messenger:consume', 'events', '-vv']
+    depends_on:
+      - mysql
+      - rmq
+      - elasticsearch
 
   mysql:
     image: mysql:8.0


### PR DESCRIPTION
When we run our containers rabbitmq need little more time to wake up than other containers so workers not working from begining.