### PR TITLE
Improve docker performance and allowing public php files in dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,20 @@ services:
   nginx:
     image: nginx:1.17-alpine
     volumes:
-      - ./etc/dev/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
-      - .:/app
+      - ./etc/dev/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - .:/app:ro
     depends_on:
       - php
 
   php:
     image: jorge07/alpine-php:7.4.3-dev
     volumes:
-      - .:/app
+      - ./:/app:rw,cached
+      # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
+      - /app/var/
+      - /app/var/cache/
+      - /app/var/logs/
+      - /app/var/sessions/
     depends_on:
       - mysql
       - rmq
@@ -22,7 +27,12 @@ services:
   workers:
     image: jorge07/alpine-php:7.4.3-dev
     volumes:
-      - .:/app
+      - ./:/app:rw,cached
+      # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
+      - /app/var/
+      - /app/var/cache/
+      - /app/var/logs/
+      - /app/var/sessions/
     command: ['/app/bin/console', 'messenger:consume', 'events', '-vv']
     depends_on:
       - mysql

--- a/etc/dev/nginx/nginx.conf
+++ b/etc/dev/nginx/nginx.conf
@@ -8,11 +8,14 @@ server {
         try_files $uri /index.php$is_args$args;
     }
 
-    location ~ ^/index\.php(/|$) {
+    location ~ \.php$ {
         fastcgi_pass php:9000;
+        fastcgi_index index.php;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param  SCRIPT_FILENAME  $realpath_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 }


### PR DESCRIPTION
## Reason

Docker file sync in windows and mac are very expensive and make things very slow. Since log ago I use Dinghy to develop in mac and performance is very close to native linux. 
As this as grow and I'm not the only one I tried during lasts weeks docker4mac and docker4windows and even if are far far away in performance against Dinghy and native, here some tricks that I found while fighting with 1-2s per request.

The results are:

[x] **Docker4Mac** ~1-2s -> 300-400ms
[x] **Docker4Windows** ~2-4s -> 350-500ms
[x] **Dinghy** 200ms-500ms -> 70-150ms