### PR TITLE
Coveralls with github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
-name: pr
+name: push
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 
@@ -11,6 +11,16 @@ jobs:
     name: Code build, lint and tests
     steps:
     - uses: actions/checkout@v1
+      with:
+        ref: master
+
+    - name: Reattach HEAD to Head Ref
+      run: git checkout "$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
+      if: github.head_ref != ''
+
+    - name: Reattach HEAD to Ref
+      run: git checkout "$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
+      if: github.head_ref == ''
 
     - name: Build
       run: make env=ci start;make env=ci wait-for-elastic;make env=ci xoff

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A boilerplate for DDD, CQRS, Event Sourcing applications using Symfony as framework and running with php7
 
-![pr](https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/workflows/pr/badge.svg)
+![push](https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/workflows/push/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/jorge07/symfony-5-es-cqrs-boilerplate/badge.svg?branch=master)](https://coveralls.io/github/jorge07/symfony-5-es-cqrs-boilerplate)
 
 Symfony 4 still available in [symfony-4 branch](https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/tree/symfony-4)


### PR DESCRIPTION
After analyzed https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/runs/747406029?check_suite_focus=true

```
git checkout --progress --force 33b70c3921c856d1e2ab1983830b6a3eccb70526
Note: switching to '33b70c3921c856d1e2ab1983830b6a3eccb70526'.
You are in 'detached HEAD' state. You can look around, make experimental
(...)
Turn off this advice by setting config variable advice.detachedHead to false
HEAD is now at 33b70c3 Fix Coverage report
```

I searched the way to leave DETACH HEAD in github-actions. I found https://github.com/actions/checkout/issues/6

So to resolve this problem https://github.com/jorge07/symfony-5-es-cqrs-boilerplate/issues/168 two separate github actions files are needed for pr and push.

Result:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/9404962/83975919-d4924b80-a8f6-11ea-8938-af216e220966.png">

