### PR TITLE
Wait for dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,3 +64,11 @@ services:
     environment:
       - "discovery.type=single-node"
       - "cluster.name=sf-events"
+
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - mysql
+      - rmq
+      - elasticsearch
+    command: mysql:3306 elasticsearch:9200 rmq:5672

--- a/makefile
+++ b/makefile
@@ -11,7 +11,11 @@ endif
 export compose env docker-os
 
 .PHONY: start
-start: erase build up db ## clean current environment, recreate dependencies and spin up again
+start: erase build start-deps up db ## clean current environment, recreate dependencies and spin up again
+
+.PHONY: start-deps
+start-deps:  ## Start all dependencies and wait for it
+		$(compose) run --rm start_dependencies
 
 .PHONY: stop
 stop: ## stop environment


### PR DESCRIPTION
Fixes #165 #173

No changes in end user.

Added an extra step to wait for all dependencies to start the project with 100% required dependencies running and avoid side effects and frustrations with veeeery slow mysql and elastic starts